### PR TITLE
Mlkit integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
     implementation(libs.moshi.adapters)
     implementation(libs.okhttp3)
     implementation(libs.coil)
+    implementation(libs.mlkitscanner)
 
     // To use Kotlin annotation processing tool (kapt)
     kapt(libs.androidx.room.compiler)

--- a/app/src/main/java/com/example/dungeontest/MainActivity.kt
+++ b/app/src/main/java/com/example/dungeontest/MainActivity.kt
@@ -186,7 +186,7 @@ fun MapDetailsCard(item: MapRecord, modifier: Modifier = Modifier) {
                 )
                 Text(
                     modifier = Modifier.padding(18.dp).weight(0.5f),
-                    text = item.pictureFileName.takeLast(20)
+                    text = item.pictureFileName.takeLast(10)
                 )
             }
         }

--- a/app/src/main/java/com/example/dungeontest/MainScreen.kt
+++ b/app/src/main/java/com/example/dungeontest/MainScreen.kt
@@ -48,7 +48,7 @@ import com.example.dungeontest.data.SettingsStorage
 import com.example.dungeontest.model.MapViewModel
 import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions
 import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.RESULT_FORMAT_JPEG
-import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.SCANNER_MODE_BASE_WITH_FILTER
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.SCANNER_MODE_FULL
 import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
 import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
 import kotlinx.coroutines.CoroutineScope
@@ -71,7 +71,7 @@ fun MainScreen(
         .setGalleryImportAllowed(true)
         .setPageLimit(1)
         .setResultFormats(RESULT_FORMAT_JPEG)
-        .setScannerMode(SCANNER_MODE_BASE_WITH_FILTER)
+        .setScannerMode(SCANNER_MODE_FULL)
         .build()
 
     val scanner = GmsDocumentScanning.getClient(options)

--- a/app/src/main/java/com/example/dungeontest/MainScreen.kt
+++ b/app/src/main/java/com/example/dungeontest/MainScreen.kt
@@ -4,9 +4,9 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Activity.RESULT_OK
-import android.content.Context
 import android.net.Uri
 import android.util.Base64
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -42,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.core.content.FileProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.dungeontest.data.SettingsStorage
@@ -54,7 +53,6 @@ import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
 import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.io.File
 
 
 @SuppressLint("RememberReturnType")
@@ -88,7 +86,6 @@ fun MainScreen(
                 photoUri = result?.pages?.get(0)?.imageUri
                 photoUri?.let {
                     val base64EncodedUri = Base64.encodeToString(photoUri.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
-                    /* navcontroller is passed from the NavGraph setup in MainActivity */
                     navController.navigate("NamingScreen/$base64EncodedUri") {
                         popUpTo("NamingScreen") { inclusive = true }
                     }
@@ -125,11 +122,11 @@ fun MainScreen(
                                 scope.launch {
                                     if (snackbarHostState.currentSnackbarData == null)
                                         snackbarHostState.showSnackbar(
-                                            "An error occurred at getStartScanIntent()",
+                                            "An error occurred while starting the scanner.",
                                             duration = SnackbarDuration.Short
                                         )
                                 }
-
+                                Log.d("MainScreen", "Error triggered at scanner.getStartScanIntent()")
                             }
                     }
                 }
@@ -191,12 +188,4 @@ fun MainScreen(
             }
         }
     }
-}
-
-fun createImageFileUri(context: Context): Uri {
-    val imagePath = File(context.getExternalFilesDir(null), "images")
-    imagePath.mkdirs()
-    //todo need to make uuid instead of hardcoded name 'photo'?
-    val imageFile = File(imagePath, "photo.jpg")
-    return FileProvider.getUriForFile(context, "${context.packageName}.file provider", imageFile)
 }

--- a/app/src/main/java/com/example/dungeontest/MainScreen.kt
+++ b/app/src/main/java/com/example/dungeontest/MainScreen.kt
@@ -67,29 +67,37 @@ fun MainScreen(
     val preferences = SettingsStorage(context)
     val viewModel = viewModel<MapViewModel>()
     
-    val options = GmsDocumentScannerOptions.Builder()
-        .setGalleryImportAllowed(true)
-        .setPageLimit(1)
-        .setResultFormats(RESULT_FORMAT_JPEG)
-        .setScannerMode(SCANNER_MODE_FULL)
-        .build()
+    val options = remember {
+        GmsDocumentScannerOptions.Builder()
+            .setGalleryImportAllowed(true)
+            .setPageLimit(1)
+            .setResultFormats(RESULT_FORMAT_JPEG)
+            .setScannerMode(SCANNER_MODE_FULL)
+            .build()
+    }
 
-    val scanner = GmsDocumentScanning.getClient(options)
+    val scanner = remember { GmsDocumentScanning.getClient(options) }
+
     var photoUri by remember {
         mutableStateOf<Uri?>(null)
     }
+
     val scannerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartIntentSenderForResult(),
         onResult = {
             if (it.resultCode == RESULT_OK) {
                 val result = GmsDocumentScanningResult.fromActivityResultIntent(it.data)
                 photoUri = result?.pages?.get(0)?.imageUri
-                photoUri?.let {
+                if (photoUri != null) {
                     val base64EncodedUri = Base64.encodeToString(photoUri.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
                     navController.navigate("NamingScreen/$base64EncodedUri") {
                         popUpTo("NamingScreen") { inclusive = true }
                     }
+                } else {
+                    Log.d("MainScreen", "photoUri is null. Result: ${result?.toString()}")
                 }
+            } else {
+                Log.d("MainScreen", "Scanner resultCode not OK.")
             }
         }
     )

--- a/app/src/main/java/com/example/dungeontest/MainScreen.kt
+++ b/app/src/main/java/com/example/dungeontest/MainScreen.kt
@@ -2,11 +2,13 @@ package com.example.dungeontest
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.net.Uri
 import android.util.Base64
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -45,6 +47,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.dungeontest.data.SettingsStorage
 import com.example.dungeontest.model.MapViewModel
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.RESULT_FORMAT_JPEG
+import com.google.mlkit.vision.documentscanner.GmsDocumentScannerOptions.SCANNER_MODE_BASE_WITH_FILTER
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanning
+import com.google.mlkit.vision.documentscanner.GmsDocumentScanningResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.io.File
@@ -61,25 +68,39 @@ fun MainScreen(
     val context = LocalContext.current
     val preferences = SettingsStorage(context)
     val viewModel = viewModel<MapViewModel>()
-    val maps = viewModel.allMaps.observeAsState()
-    var photoUri by remember { mutableStateOf<Uri?>(null) }
-    val snackbarHostState = remember { SnackbarHostState() }
-    val cameraLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.TakePicture()
-    ) { success ->
-        if (success) {
-            photoUri?.let {
-                Log.v("MainScreen", "Photo URI: $it")
-                /* Encode the URI to base64 because it's a file path. Navigation uses / */
+    
+    val options = GmsDocumentScannerOptions.Builder()
+        .setGalleryImportAllowed(true)
+        .setPageLimit(1)
+        .setResultFormats(RESULT_FORMAT_JPEG)
+        .setScannerMode(SCANNER_MODE_BASE_WITH_FILTER)
+        .build()
 
-                 val base64EncodedUri = Base64.encodeToString(it.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
-                /* navcontroller is passed from the NavGraph setup in MainActivity */
-                navController.navigate("NamingScreen/$base64EncodedUri") {
-                    popUpTo("NamingScreen") { inclusive = true }
+    val scanner = GmsDocumentScanning.getClient(options)
+    var photoUri by remember {
+        mutableStateOf<Uri?>(null)
+    }
+    val scannerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
+        onResult = {
+            if (it.resultCode == RESULT_OK) {
+                val result = GmsDocumentScanningResult.fromActivityResultIntent(it.data)
+                photoUri = result?.pages?.get(0)?.imageUri
+                photoUri?.let {
+                    val base64EncodedUri = Base64.encodeToString(photoUri.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+                    /* navcontroller is passed from the NavGraph setup in MainActivity */
+                    navController.navigate("NamingScreen/$base64EncodedUri") {
+                        popUpTo("NamingScreen") { inclusive = true }
+                    }
                 }
             }
         }
-    }
+    )
+
+    
+    val maps = viewModel.allMaps.observeAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
@@ -94,18 +115,33 @@ fun MainScreen(
                                     duration = SnackbarDuration.Short
                                 )
                     } else {
-                        photoUri = createImageFileUri(context)
-                        cameraLauncher.launch(photoUri!!)
+                        scanner.getStartScanIntent(context as Activity)
+                            .addOnSuccessListener {
+                                scannerLauncher.launch(
+                                    IntentSenderRequest.Builder(it).build()
+                                )
+                            }
+                            .addOnFailureListener{
+                                scope.launch {
+                                    if (snackbarHostState.currentSnackbarData == null)
+                                        snackbarHostState.showSnackbar(
+                                            "An error occurred at getStartScanIntent()",
+                                            duration = SnackbarDuration.Short
+                                        )
+                                }
+
+                            }
                     }
                 }
             }
 
-
         } else {
             scope.launch {
-                // Show a snackbar message. Ideally shouldn't overlap
-                // TODO: Handle limited invokations of a snackbar
-                snackbarHostState.showSnackbar("Camera permission is required to take photos")
+                if (snackbarHostState.currentSnackbarData == null)
+                    snackbarHostState.showSnackbar(
+                        "Camera permission is required to take photos",
+                        duration = SnackbarDuration.Short
+                    )
             }
         }
     }
@@ -131,7 +167,9 @@ fun MainScreen(
         },
         floatingActionButton = {
             FloatingActionButton(onClick = {
+
                 permissionLauncher.launch(Manifest.permission.CAMERA)
+
             }) {
                 Icon(Icons.Filled.Add, contentDescription = "Floating action button.")
 

--- a/app/src/main/java/com/example/dungeontest/MainScreen.kt
+++ b/app/src/main/java/com/example/dungeontest/MainScreen.kt
@@ -97,7 +97,7 @@ fun MainScreen(
                     Log.d("MainScreen", "photoUri is null. Result: ${result?.toString()}")
                 }
             } else {
-                Log.d("MainScreen", "Scanner resultCode not OK.")
+                Log.d("MainScreen", "Scanner resultCode not OK. Result code: ${it.resultCode}")
             }
         }
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ lifecycleLivedataKtx = "2.8.1"
 junitJupiter = "5.8.1"
 okhttp3 = "4.9.2"
 coroutineImageLoader = "2.6.0"
+mlkitscanner = "16.0.0-beta1"
 
 
 [libraries]
@@ -59,6 +60,7 @@ junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.r
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 coil = { module = "io.coil-kt:coil-compose", version.ref = "coroutineImageLoader" }
+mlkitscanner = { module = "com.google.android.gms:play-services-mlkit-document-scanner", version.ref = "mlkitscanner" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Integrates MLKit as a replacement to the old way we captured photos and assigned them to a predefined photo uri. With this, images are cached in a subfolder created by Mlkit with appropriate UUIDs. 

All the above on top of the cool shit that MLKit document scanning offers of course